### PR TITLE
feat(scan): scan support string

### DIFF
--- a/pgvector.go
+++ b/pgvector.go
@@ -54,6 +54,8 @@ func (v *Vector) Scan(src interface{}) (err error) {
 	switch src := src.(type) {
 	case []byte:
 		return v.Parse(string(src))
+	case string:
+		return v.Parse(src)
 	default:
 		return fmt.Errorf("unsupported data type: %T", src)
 	}


### PR DESCRIPTION
When using the gorm find method, the returned data type is string