### PR TITLE
Parse and String optimization

### DIFF
--- a/pgvector.go
+++ b/pgvector.go
@@ -41,8 +41,8 @@ func (v Vector) String() string {
 
 // Parse parses a string representation of a vector.
 func (v *Vector) Parse(s string) error {
-	v.vec = make([]float32, 0)
 	sp := strings.Split(s[1:len(s)-1], ",")
+	v.vec = make([]float32, 0, len(sp))
 	for i := 0; i < len(sp); i++ {
 		n, err := strconv.ParseFloat(sp[i], 32)
 		if err != nil {

--- a/pgvector.go
+++ b/pgvector.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"unsafe"
 )
 
 // Vector is a wrapper for []float32 to implement sql.Scanner and driver.Valuer.
@@ -26,20 +25,18 @@ func (v Vector) Slice() []float32 {
 
 // String returns a string representation of the vector.
 func (v Vector) String() string {
-	if len(v.vec) == 0 {
-		return "[]"
-	}
-	// brackets (2) + commas (len(v.vec)-1) + floats (len(v.vec))
-	buf := make([]byte, 0, 2+2*len(v.vec)-1)
+	buf := make([]byte, 0, 2+16*len(v.vec))
 	buf = append(buf, '[')
 
 	for i := 0; i < len(v.vec); i++ {
+		if i > 0 {
+			buf = append(buf, ',')
+		}
 		buf = strconv.AppendFloat(buf, float64(v.vec[i]), 'f', -1, 32)
-		buf = append(buf, ',')
 	}
 
-	buf[len(buf)-1] = ']'
-	return unsafe.String(unsafe.SliceData(buf), len(buf))
+	buf = append(buf, ']')
+	return string(buf)
 }
 
 // Parse parses a string representation of a vector.

--- a/pgvector.go
+++ b/pgvector.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unsafe"
 )
 
 // Vector is a wrapper for []float32 to implement sql.Scanner and driver.Valuer.
@@ -25,18 +26,20 @@ func (v Vector) Slice() []float32 {
 
 // String returns a string representation of the vector.
 func (v Vector) String() string {
-	var buf strings.Builder
-	buf.WriteString("[")
+	if len(v.vec) == 0 {
+		return "[]"
+	}
+	// brackets (2) + commas (len(v.vec)-1) + floats (len(v.vec))
+	buf := make([]byte, 0, 2+2*len(v.vec)-1)
+	buf = append(buf, '[')
 
 	for i := 0; i < len(v.vec); i++ {
-		if i > 0 {
-			buf.WriteString(",")
-		}
-		buf.WriteString(strconv.FormatFloat(float64(v.vec[i]), 'f', -1, 32))
+		buf = strconv.AppendFloat(buf, float64(v.vec[i]), 'f', -1, 32)
+		buf = append(buf, ',')
 	}
 
-	buf.WriteString("]")
-	return buf.String()
+	buf[len(buf)-1] = ']'
+	return unsafe.String(unsafe.SliceData(buf), len(buf))
 }
 
 // Parse parses a string representation of a vector.


### PR DESCRIPTION
First of all, thanks for the great work!

This pull request includes small optimizations.

All benchmarks were conducted on the MacBook Air M2 8 GB.
The code of benchmarks you can see [in gist](https://gist.github.com/Gleonett/643de183f8b8d11de2032bd91755c2f6).

#### Parse
`Benchmark_Vector_Parse` - old implementation.
`Benchmark_Vector_ParsePreallocate` - new implementation.
```
Benchmark_Vector_Parse-8                   26210             44269 ns/op           29304 B/op         12 allocs/op
Benchmark_Vector_ParsePreallocate-8        28431             42282 ns/op           20480 B/op          2 allocs/op
```
#### String
`NoPreallocation` - old implementation.
`Preallocation` - new implementation.
```
Benchmark_Vector_String/NoPreallocation/empty-8                 49260325                23.49 ns/op            8 B/op          1 allocs/op
Benchmark_Vector_String/Preallocation/empty-8                   358203250                3.340 ns/op           0 B/op          0 allocs/op
Benchmark_Vector_String/NoPreallocation/Zero3-8                  7309263               164.6 ns/op            80 B/op          4 allocs/op
Benchmark_Vector_String/Preallocation/Zero3-8                   19650412                61.09 ns/op            8 B/op          1 allocs/op
Benchmark_Vector_String/NoPreallocation/Zero16-8                 1366677               857.1 ns/op           504 B/op         20 allocs/op
Benchmark_Vector_String/Preallocation/Zero16-8                   4393969               274.0 ns/op            48 B/op          1 allocs/op
Benchmark_Vector_String/NoPreallocation/Zero256-8                  98455             11741 ns/op            8056 B/op        264 allocs/op
Benchmark_Vector_String/Preallocation/Zero256-8                   307315              3886 ns/op             576 B/op          1 allocs/op
Benchmark_Vector_String/NoPreallocation/Zero512-8                  50676             23064 ns/op           15608 B/op        521 allocs/op
Benchmark_Vector_String/Preallocation/Zero512-8                   154672              7723 ns/op            1152 B/op          1 allocs/op
Benchmark_Vector_String/NoPreallocation/Zero1024-8                 26192             45731 ns/op           33016 B/op       1035 allocs/op
Benchmark_Vector_String/Preallocation/Zero1024-8                   76116             15457 ns/op            2304 B/op          1 allocs/op
Benchmark_Vector_String/NoPreallocation/Zero4096-8                  6620            180749 ns/op          132601 B/op       4111 allocs/op
Benchmark_Vector_String/Preallocation/Zero4096-8                   19446             61884 ns/op            9472 B/op          1 allocs/op
Benchmark_Vector_String/NoPreallocation/Zero16000-8                 1695            702863 ns/op          538364 B/op      16020 allocs/op
Benchmark_Vector_String/Preallocation/Zero16000-8                   5046            238915 ns/op           32768 B/op          1 allocs/op
Benchmark_Vector_String/NoPreallocation/Random3-8                2534774               471.2 ns/op           240 B/op         10 allocs/op
Benchmark_Vector_String/Preallocation/Random3-8                  4073322               300.9 ns/op           120 B/op          4 allocs/op
Benchmark_Vector_String/NoPreallocation/Random16-8                530437              2252 ns/op            1144 B/op         38 allocs/op
Benchmark_Vector_String/Preallocation/Random16-8                  889797              1335 ns/op             608 B/op          4 allocs/op
Benchmark_Vector_String/NoPreallocation/Random256-8                31573             37854 ns/op           18624 B/op        523 allocs/op
Benchmark_Vector_String/Preallocation/Random256-8                  52341             22703 ns/op            8000 B/op          5 allocs/op
Benchmark_Vector_String/NoPreallocation/Random512-8                15878             76054 ns/op           45104 B/op       1038 allocs/op
Benchmark_Vector_String/Preallocation/Random512-8                  25737             46777 ns/op           24448 B/op          7 allocs/op
Benchmark_Vector_String/NoPreallocation/Random1024-8                7684            155936 ns/op           87088 B/op       2064 allocs/op
Benchmark_Vector_String/Preallocation/Random1024-8                 12742             93851 ns/op           43520 B/op          7 allocs/op
Benchmark_Vector_String/NoPreallocation/Random4096-8                2005            606792 ns/op          374163 B/op       8213 allocs/op
Benchmark_Vector_String/Preallocation/Random4096-8                  3201            374256 ns/op          159617 B/op          7 allocs/op
Benchmark_Vector_String/NoPreallocation/Random16000-8                530           2386481 ns/op         1321708 B/op      32025 allocs/op
Benchmark_Vector_String/Preallocation/Random16000-8                  816           1441948 ns/op          606211 B/op          7 allocs/op
```

