### PR TITLE
Added Conn interface for pgx.Conn/pgxpool.Conn

### DIFF
--- a/pgx/register.go
+++ b/pgx/register.go
@@ -8,7 +8,12 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-func RegisterTypes(ctx context.Context, conn *pgx.Conn) error {
+// Conn interface to support both pgx.Conn and pgxpool.Conn
+type Conn interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+func RegisterTypes(ctx context.Context, conn Conn) error {
 	var vectorOid *uint32
 	var halfvecOid *uint32
 	var sparsevecOid *uint32
@@ -21,7 +26,20 @@ func RegisterTypes(ctx context.Context, conn *pgx.Conn) error {
 		return fmt.Errorf("vector type not found in the database")
 	}
 
-	tm := conn.TypeMap()
+	// Determine how to access the TypeMap based on the connection type
+	var tm *pgtype.Map
+	switch c := conn.(type) {
+	case *pgx.Conn:
+		// Direct access for pgx.Conn
+		tm = c.TypeMap()
+	case interface{ Conn() *pgx.Conn }:
+		// For pgxpool.Conn and any custom types that provide access to the underlying pgx.Conn
+		tm = c.Conn().TypeMap()
+	default:
+		// If an unsupported connection type is passed, return an error
+		return fmt.Errorf("unsupported connection type: %T", conn)
+	}
+
 	tm.RegisterType(&pgtype.Type{Name: "vector", OID: *vectorOid, Codec: &VectorCodec{}})
 
 	if halfvecOid != nil {


### PR DESCRIPTION
```go
err := pgxvector.RegisterTypes(ctx, conn)
```

The arg conn is of `*pgx.Conn` type. Now it also accepts `*pgxpool.Conn`. If we must use *pgx.Conn, would someone kind to enlighten me?
