### PR TITLE
feat(scan) handle nil when scan vector

### DIFF
--- a/vector.go
+++ b/vector.go
@@ -91,6 +91,10 @@ var _ sql.Scanner = (*Vector)(nil)
 
 // Scan implements the sql.Scanner interface.
 func (v *Vector) Scan(src interface{}) (err error) {
+	if src == nil {
+		return nil
+	}
+
 	switch src := src.(type) {
 	case []byte:
 		return v.Parse(string(src))


### PR DESCRIPTION
Since I support multiple embedding providers (Vertex 768, OpenAI 1536), this field is nullable based on the selected method.