### PR TITLE
fix: handle empty and invalid input in vector Parse

### DIFF
--- a/halfvec.go
+++ b/halfvec.go
@@ -35,7 +35,15 @@ func (v HalfVector) String() string {
 
 // Parse parses a string representation of a half vector.
 func (v *HalfVector) Parse(s string) error {
-	sp := strings.Split(s[1:len(s)-1], ",")
+	if len(s) < 2 || s[0] != '[' || s[len(s)-1] != ']' {
+		return fmt.Errorf("invalid half vector format")
+	}
+	inner := s[1 : len(s)-1]
+	if inner == "" {
+		v.vec = []float32{}
+		return nil
+	}
+	sp := strings.Split(inner, ",")
 	v.vec = make([]float32, 0, len(sp))
 	for i := 0; i < len(sp); i++ {
 		n, err := strconv.ParseFloat(sp[i], 32)

--- a/sparsevec.go
+++ b/sparsevec.go
@@ -95,19 +95,37 @@ func (v SparseVector) String() string {
 // Parse parses a string representation of a sparse vector.
 func (v *SparseVector) Parse(s string) error {
 	sp := strings.SplitN(s, "/", 2)
+	if len(sp) != 2 {
+		return fmt.Errorf("invalid sparse vector format")
+	}
 
 	dim, err := strconv.ParseInt(sp[1], 10, 32)
 	if err != nil {
 		return err
 	}
 
-	elements := strings.Split(sp[0][1:len(sp[0])-1], ",")
+	body := sp[0]
+	if len(body) < 2 || body[0] != '{' || body[len(body)-1] != '}' {
+		return fmt.Errorf("invalid sparse vector format")
+	}
+
+	inner := body[1 : len(body)-1]
 	v.dim = int32(dim)
+	if inner == "" {
+		v.indices = []int32{}
+		v.values = []float32{}
+		return nil
+	}
+
+	elements := strings.Split(inner, ",")
 	v.indices = make([]int32, 0, len(elements))
 	v.values = make([]float32, 0, len(elements))
 
 	for i := 0; i < len(elements); i++ {
 		ep := strings.SplitN(elements[i], ":", 2)
+		if len(ep) != 2 {
+			return fmt.Errorf("invalid sparse vector format")
+		}
 
 		n, err := strconv.ParseInt(ep[0], 10, 32)
 		if err != nil {

--- a/test/halfvec_test.go
+++ b/test/halfvec_test.go
@@ -34,6 +34,35 @@ func TestHalfVectorParse(t *testing.T) {
 	}
 }
 
+func TestHalfVectorParseEmpty(t *testing.T) {
+	var vec pgvector.HalfVector
+	err := vec.Parse("[]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vec.Slice()) != 0 {
+		t.Errorf("got %v, want empty", vec.Slice())
+	}
+
+	empty := pgvector.NewHalfVector([]float32{})
+	err = vec.Parse(empty.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vec.Slice()) != 0 {
+		t.Errorf("got %v, want empty", vec.Slice())
+	}
+}
+
+func TestHalfVectorParseInvalid(t *testing.T) {
+	for _, s := range []string{"", "[", "]", "1,2,3", "[1,2,3"} {
+		var vec pgvector.HalfVector
+		if err := vec.Parse(s); err == nil {
+			t.Errorf("Parse(%q) succeeded, want error", s)
+		}
+	}
+}
+
 func TestHalfVectorMarshal(t *testing.T) {
 	vec := pgvector.NewHalfVector([]float32{1, 2, 3})
 	data, err := json.Marshal(vec)

--- a/test/sparsevec_test.go
+++ b/test/sparsevec_test.go
@@ -74,3 +74,39 @@ func TestSparseVectorParse(t *testing.T) {
 		t.Error()
 	}
 }
+
+func TestSparseVectorParseEmpty(t *testing.T) {
+	var vec pgvector.SparseVector
+	err := vec.Parse("{}/3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vec.Dimensions() != 3 {
+		t.Errorf("dimensions = %d, want 3", vec.Dimensions())
+	}
+	if len(vec.Indices()) != 0 || len(vec.Values()) != 0 {
+		t.Errorf("got indices=%v values=%v, want empty", vec.Indices(), vec.Values())
+	}
+	if !reflect.DeepEqual(vec.Slice(), []float32{0, 0, 0}) {
+		t.Errorf("slice = %v, want [0 0 0]", vec.Slice())
+	}
+
+	// Round-trip empty sparse vector (all zeros)
+	empty := pgvector.NewSparseVector([]float32{0, 0, 0})
+	err = vec.Parse(empty.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vec.Dimensions() != 3 || len(vec.Indices()) != 0 {
+		t.Errorf("got dim=%d indices=%v, want dim=3 empty indices", vec.Dimensions(), vec.Indices())
+	}
+}
+
+func TestSparseVectorParseInvalid(t *testing.T) {
+	for _, s := range []string{"", "{}", "{1:1}", "1:1/3", "{1}/3", "{1:}/3"} {
+		var vec pgvector.SparseVector
+		if err := vec.Parse(s); err == nil {
+			t.Errorf("Parse(%q) succeeded, want error", s)
+		}
+	}
+}

--- a/test/vector_test.go
+++ b/test/vector_test.go
@@ -34,6 +34,36 @@ func TestVectorParse(t *testing.T) {
 	}
 }
 
+func TestVectorParseEmpty(t *testing.T) {
+	var vec pgvector.Vector
+	err := vec.Parse("[]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vec.Slice()) != 0 {
+		t.Errorf("got %v, want empty", vec.Slice())
+	}
+
+	// Round-trip empty vector produced by String()
+	empty := pgvector.NewVector([]float32{})
+	err = vec.Parse(empty.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vec.Slice()) != 0 {
+		t.Errorf("got %v, want empty", vec.Slice())
+	}
+}
+
+func TestVectorParseInvalid(t *testing.T) {
+	for _, s := range []string{"", "[", "]", "1,2,3", "[1,2,3"} {
+		var vec pgvector.Vector
+		if err := vec.Parse(s); err == nil {
+			t.Errorf("Parse(%q) succeeded, want error", s)
+		}
+	}
+}
+
 func TestVectorMarshal(t *testing.T) {
 	vec := pgvector.NewVector([]float32{1, 2, 3})
 	data, err := json.Marshal(vec)

--- a/vector.go
+++ b/vector.go
@@ -45,7 +45,15 @@ func (v Vector) String() string {
 
 // Parse parses a string representation of a vector.
 func (v *Vector) Parse(s string) error {
-	sp := strings.Split(s[1:len(s)-1], ",")
+	if len(s) < 2 || s[0] != '[' || s[len(s)-1] != ']' {
+		return fmt.Errorf("invalid vector format")
+	}
+	inner := s[1 : len(s)-1]
+	if inner == "" {
+		v.vec = []float32{}
+		return nil
+	}
+	sp := strings.Split(inner, ",")
 	v.vec = make([]float32, 0, len(sp))
 	for i := 0; i < len(sp); i++ {
 		n, err := strconv.ParseFloat(sp[i], 32)


### PR DESCRIPTION
## Summary
- `Vector.Parse`, `HalfVector.Parse`, and `SparseVector.Parse` panicked on short/malformed input (e.g. `""`, `"["`) due to unchecked slice bounds.
- Valid empty forms failed to parse: `"[]"` and `"{}/N"` (empty sparse) because `strings.Split` produced a single empty element that failed `ParseFloat`/`ParseInt`.
- Empty values produced by `String()` / `NewSparseVector([]float32{0,...})` could not round-trip through `Parse`.

## Changes
- Validate bracket/brace format before slicing.
- Treat empty interiors (`[]`, `{}/N`) as zero-length data.
- Return clear format errors instead of panicking.
- Unit tests for empty round-trips and invalid inputs.

## Test plan
- [x] `go test -count=1 -run 'TestVectorParse|TestHalfVectorParse|TestSparseVectorParse' vector_test.go halfvec_test.go sparsevec_test.go` (in `test/`)
- [x] Existing parse tests still pass