### PR TITLE
fix: trim whitespace when parsing vector and halfvec text

### DIFF
--- a/halfvec.go
+++ b/halfvec.go
@@ -36,6 +36,7 @@ func (v HalfVector) String() string {
 // Parse parses a string representation of a half vector.
 func (v *HalfVector) Parse(s string) error {
 	// TODO check brackets in 0.5.0
+	s = strings.TrimSpace(s)
 	if len(s) < 2 {
 		return fmt.Errorf("malformed halfvec literal")
 	}
@@ -48,7 +49,7 @@ func (v *HalfVector) Parse(s string) error {
 	sp := strings.Split(s[1:len(s)-1], ",")
 	v.vec = make([]float32, 0, len(sp))
 	for i := 0; i < len(sp); i++ {
-		n, err := strconv.ParseFloat(sp[i], 32)
+		n, err := strconv.ParseFloat(strings.TrimSpace(sp[i]), 32)
 		if err != nil {
 			return err
 		}

--- a/parse_space_test.go
+++ b/parse_space_test.go
@@ -1,0 +1,23 @@
+package pgvector
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseTrimSpace(t *testing.T) {
+	var v Vector
+	if err := v.Parse(" [1, 2, 3] "); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(v.Slice(), []float32{1, 2, 3}) {
+		t.Fatalf("%v", v.Slice())
+	}
+	var h HalfVector
+	if err := h.Parse(" [4, 5] "); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(h.Slice(), []float32{4, 5}) {
+		t.Fatalf("%v", h.Slice())
+	}
+}

--- a/test/halfvec_test.go
+++ b/test/halfvec_test.go
@@ -57,6 +57,14 @@ func TestHalfVectorParse(t *testing.T) {
 	if err == nil || !errors.Is(err, strconv.ErrRange) {
 		t.Error()
 	}
+
+	err = vec.Parse(" [1, 2, 3] ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(vec.Slice(), []float32{1, 2, 3}) {
+		t.Error()
+	}
 }
 
 func TestHalfVectorMarshal(t *testing.T) {

--- a/test/vector_test.go
+++ b/test/vector_test.go
@@ -57,6 +57,15 @@ func TestVectorParse(t *testing.T) {
 	if err == nil || !errors.Is(err, strconv.ErrRange) {
 		t.Error()
 	}
+
+	// Surrounding and per-element whitespace should parse.
+	err = vec.Parse(" [1, 2, 3] ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(vec.Slice(), []float32{1, 2, 3}) {
+		t.Error()
+	}
 }
 
 func TestVectorMarshal(t *testing.T) {

--- a/vector.go
+++ b/vector.go
@@ -46,6 +46,7 @@ func (v Vector) String() string {
 // Parse parses a string representation of a vector.
 func (v *Vector) Parse(s string) error {
 	// TODO check brackets in 0.5.0
+	s = strings.TrimSpace(s)
 	if len(s) < 2 {
 		return fmt.Errorf("malformed vector literal")
 	}
@@ -58,7 +59,7 @@ func (v *Vector) Parse(s string) error {
 	sp := strings.Split(s[1:len(s)-1], ",")
 	v.vec = make([]float32, 0, len(sp))
 	for i := 0; i < len(sp); i++ {
-		n, err := strconv.ParseFloat(sp[i], 32)
+		n, err := strconv.ParseFloat(strings.TrimSpace(sp[i]), 32)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## What

`Vector.Parse` and `HalfVector.Parse` trim surrounding whitespace and per-element spaces before `ParseFloat`.

## Why

Literals like `[1, 2, 3]` or ` [1,2,3] ` show up in logs and hand-written input. `strconv.ParseFloat` rejects leading spaces, so valid content failed.

## Test

- `TestParseTrimSpace`
- extended `TestVectorParse` / `TestHalfVectorParse`